### PR TITLE
Add method to create a Stripe token from card parameters

### DIFF
--- a/StripeNative/StripeNativeManager.m
+++ b/StripeNative/StripeNativeManager.m
@@ -255,4 +255,28 @@ RCT_EXPORT_METHOD(failure: (RCTPromiseResolveBlock)resolve rejector:(RCTPromiseR
     resolve(@[[NSNull null]]);
 }
 
+RCT_EXPORT_METHOD(createTokenWithCard:(NSDictionary *)cardParams resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject) {
+    STPCardParams *card = [[STPCardParams alloc] init];
+    NSNumberFormatter * numberFormatter = [[NSNumberFormatter alloc] init];
+    for (NSString *propertyName in [STPCardParams propertyNamesToFormFieldNamesMapping]) {
+        id value = [cardParams objectForKey:propertyName];
+        if ([propertyName isEqualToString:@"expMonth"] || [propertyName isEqualToString:@"expYear"]) {
+            NSNumber *number = [numberFormatter numberFromString:value];
+            if (number) {
+                [card setValue:number forKey:propertyName];
+            }
+        } else {
+            [card setValue:value forKey:propertyName];
+        }
+    }
+    [[STPAPIClient sharedClient] createTokenWithCard:card
+                                          completion:^(STPToken *token, NSError *error) {
+                                              if (error == nil) {
+                                                  resolve(token.tokenId);
+                                              } else {
+                                                  reject(error);
+                                              }
+                                          }];
+}
+
 @end

--- a/StripeNative/StripeNativeManager.m
+++ b/StripeNative/StripeNativeManager.m
@@ -261,7 +261,10 @@ RCT_EXPORT_METHOD(createTokenWithCard:(NSDictionary *)cardParams resolver:(RCTPr
     for (NSString *propertyName in [STPCardParams propertyNamesToFormFieldNamesMapping]) {
         id value = [cardParams objectForKey:propertyName];
         if ([propertyName isEqualToString:@"expMonth"] || [propertyName isEqualToString:@"expYear"]) {
-            NSNumber *number = [numberFormatter numberFromString:value];
+            NSNumber *number = value;
+            if ([number isKindOfClass:[NSString class]]) {
+                number = [numberFormatter numberFromString:value];
+            }
             if (number) {
                 [card setValue:number forKey:propertyName];
             }

--- a/index.ios.js
+++ b/index.ios.js
@@ -70,6 +70,10 @@ var NativeStripe = {
   paymentRequestWithCardForm: (items) => {
     return StripeNativeManager.paymentRequestWithCardForm(getTotal(items).toFixed(2).toString());
   },
+
+  createTokenWithCard: (cardParams) => {
+    return StripeNativeManager.createTokenWithCard(cardParams);
+  },
 };
 
 getTotal = (items) => {


### PR DESCRIPTION
Thanks for creating this! I'm using the Apple pay part of it, but we also allow users to input their credit card in to our own form, so I needed a way to easily create charges.

This PR exposes `createTokenWithCard` on the Stripe framework so that charges can be created manually.
