### PR TITLE
Dismiss the Apple pay view once payment is complete

### DIFF
--- a/StripeNative/StripeNativeManager.m
+++ b/StripeNative/StripeNativeManager.m
@@ -137,6 +137,7 @@ RCT_EXPORT_MODULE();
                               [self getContactDetails:payment.shippingContact],
                               [self getContactDetails:payment.billingContact],
                               ]);
+            [rootViewController dismissViewControllerAnimated:YES completion:nil];
         }
     }];
 }


### PR DESCRIPTION
Currently when a charge is successful the apple pay controller doesn't dismiss.

I couldn't find a way to easily do this from the react side.

I figure that the view should generally dismiss itself when the payment is successful anyway.

Let me know if there's a better way we should do this.
