### PR TITLE
Add a target for cocoapods 1.0 compat

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,1 +1,3 @@
-pod 'Stripe'
+target 'StripeNative' do
+  pod 'Stripe'
+end


### PR DESCRIPTION
Hey!

I can't seem to install this package with cocoapods 1.0, it requires a explicit target now:

> The dependency `Stripe` is not used in any concrete target.

I can't for the love of god run cocoapods 0.39 here, so not sure if this will work retroactive – although I suspect it is. Might be a good idea to test with that setup.
