### PR TITLE
Add Support for RN 0.42.x

### DIFF
--- a/StripeNative/StripeNativeManager.m
+++ b/StripeNative/StripeNativeManager.m
@@ -7,7 +7,7 @@
 
 #import <Stripe/Stripe.h>
 
-#import "RCTEventDispatcher.h"
+#import <React/RCTEventDispatcher.h>
 #import "RCTUtils.h"
 
 #import "PaymentViewController.h"


### PR DESCRIPTION
Updated RCTEventDispatcher.h to React/RCTEventDispatcher.h to fix build fail caused by duplicate declaration.